### PR TITLE
Replace Transport Client by Rest Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<junit.platform.version>1.0.0</junit.platform.version>
 		<org.apache.jmeter.version>3.1</org.apache.jmeter.version>
 		<org.apache.commons>3.4</org.apache.commons>
-		<org.elasticsearch.client>5.5.2</org.elasticsearch.client>
+		<org.elasticsearch.client>6.0.0</org.elasticsearch.client>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -54,12 +54,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
-			<artifactId>rest</artifactId>
-			<version>${org.elasticsearch.client}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.client</groupId>
-			<artifactId>transport</artifactId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
 			<version>${org.elasticsearch.client}</version>
 		</dependency>
 		<dependency>
@@ -139,7 +134,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.4.1</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>
@@ -148,33 +143,15 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-                            <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.apache.jmeter:*</exclude>
                                     <exclude>commons-codec:*</exclude>
                                     <exclude>commons-logging:*</exclude>
                                     <exclude>org.apache.httpcomponents:*</exclude>
+                                    <exclude>net.java.dev.jna:*</exclude>
                                 </excludes>
                             </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.joda</pattern>
-                                    <shadedPattern>net.delirius.dep.org.joda</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.yaml.snakeyaml</pattern>
-                                    <shadedPattern>net.delirius.dep.org.yaml.snakeyaml</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.fasterxml.jackson</pattern>
-                                    <shadedPattern>net.delirius.dep.com.fasterxml.jackson</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.HdrHistogram</pattern>
-                                    <shadedPattern>net.delirius.dep.org.HdrHistogram</shadedPattern>
-                                </relocation>
-                            </relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/net/delirius/jmeter/backendlistener/elasticsearch/ElasticsearchBackend.java
+++ b/src/main/java/net/delirius/jmeter/backendlistener/elasticsearch/ElasticsearchBackend.java
@@ -1,6 +1,6 @@
 package net.delirius.jmeter.backendlistener.elasticsearch;
 
-import java.net.InetAddress;
+import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
@@ -20,13 +21,13 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,34 +39,34 @@ import org.slf4j.LoggerFactory;
  * @source_2: https://github.com/zumo64/ELK_POC
  */
 public class ElasticsearchBackend extends AbstractBackendListenerClient {
-    private static final String BUILD_NUMBER = "BuildNumber";
+    private static final String BUILD_NUMBER    = "BuildNumber";
+    private static final String ES_SCHEME       = "es.scheme";
     private static final String ES_HOST         = "es.host";
     private static final String ES_PORT         = "es.transport.port";
     private static final String ES_INDEX        = "es.index";
     private static final String ES_TIMESTAMP    = "es.timestamp";
     private static final String ES_STATUS_CODE  = "es.status.code";
-    private static final String ES_CLUSTER      = "es.cluster";
     private static final String ES_BULK_SIZE    = "es.bulk.size";
     private static final String ES_TIMEOUT_MS   = "es.timout.ms";
     private static final long DEFAULT_TIMEOUT_MS = 200L;
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchBackend.class);
 
-    private PreBuiltTransportClient client;
+    private RestHighLevelClient client;
     private String index;
     private int buildNumber;
     private int bulkSize;
-    private BulkRequestBuilder bulkRequest;
+    private BulkRequest bulkRequest;
     private long timeoutMs;
 
     @Override
     public Arguments getDefaultParameters() {
         Arguments parameters = new Arguments();
+        parameters.addArgument(ES_SCHEME, "http");
         parameters.addArgument(ES_HOST, null);
-        parameters.addArgument(ES_PORT, "9300");
+        parameters.addArgument(ES_PORT, "9200");
         parameters.addArgument(ES_INDEX, null);
         parameters.addArgument(ES_TIMESTAMP, "yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
         parameters.addArgument(ES_STATUS_CODE, "531");
-        parameters.addArgument(ES_CLUSTER, "elasticsearch");
         parameters.addArgument(ES_BULK_SIZE, "100");
         parameters.addArgument(ES_TIMEOUT_MS, Long.toString(DEFAULT_TIMEOUT_MS));
         return parameters;
@@ -80,13 +81,17 @@ public class ElasticsearchBackend extends AbstractBackendListenerClient {
             this.buildNumber  = (JMeterUtils.getProperty(ElasticsearchBackend.BUILD_NUMBER) != null 
                     && JMeterUtils.getProperty(ElasticsearchBackend.BUILD_NUMBER).trim() != "") 
                     ? Integer.parseInt(JMeterUtils.getProperty(ElasticsearchBackend.BUILD_NUMBER)) : 0;
-            Settings settings = Settings.builder().put("cluster.name", context.getParameter(ES_CLUSTER)).build();
             String host         = context.getParameter(ES_HOST);
             int port         = Integer.parseInt(context.getParameter(ES_PORT));
-            this.client       = new PreBuiltTransportClient(settings);
-            this.client.addTransportAddress(
-                    new InetSocketTransportAddress(InetAddress.getByName(host), port));
-            this.bulkRequest  = this.client.prepareBulk();
+            this.client       = new RestHighLevelClient(
+                        RestClient.builder(
+                            new HttpHost(host, port, context.getParameter(ES_SCHEME, "http")))
+                        .setRequestConfigCallback(requestConfigBuilder -> 
+                             requestConfigBuilder
+                                        .setConnectTimeout(5000)
+                                        .setSocketTimeout((int)timeoutMs))
+                        .setMaxRetryTimeoutMillis(60000));
+            this.bulkRequest = new BulkRequest().timeout(TimeValue.timeValueMillis(timeoutMs));
             super.setupTest(context);
         } catch (Exception e) {
             throw new IllegalStateException("Unable to setup connectivity to ES", e);
@@ -96,25 +101,18 @@ public class ElasticsearchBackend extends AbstractBackendListenerClient {
     @Override
     public void handleSampleResults(List<SampleResult> results, BackendListenerContext context) {
         for(SampleResult sr : results) {
-            this.bulkRequest.add(this.client.prepareIndex(this.index, "SampleResult").setSource(this.getElasticData(sr, context), XContentType.JSON));
+            this.bulkRequest.add(
+                    new IndexRequest(this.index, "SampleResult").source(this.getElasticData(sr, context), 
+                            XContentType.JSON));
         }
 
         if(this.bulkRequest.numberOfActions() >= this.bulkSize) {
             try {
-                BulkResponse bulkResponse = this.bulkRequest.get(TimeValue.timeValueMillis(timeoutMs));
-                if (bulkResponse.hasFailures()) {
-                    if(logger.isErrorEnabled()) {
-                        logger.error("Failed to write a result on {}: {}",
-                                index, bulkResponse.buildFailureMessage());
-                    }
-                } else {
-                    logger.debug("Wrote {} results in {}.",
-                            index);
-                }
+                sendRequest(bulkRequest);
             } catch (Exception e) {
                 logger.error("Error sending data to ES, data will be lost", e);
             } finally {
-                this.bulkRequest = this.client.prepareBulk();
+                this.bulkRequest = new BulkRequest().timeout(TimeValue.timeValueMillis(timeoutMs));
             }
         }
     }
@@ -122,10 +120,23 @@ public class ElasticsearchBackend extends AbstractBackendListenerClient {
     @Override
     public void teardownTest(BackendListenerContext context) throws Exception {
         if(this.bulkRequest.numberOfActions() > 0) {
-            this.bulkRequest.get();
+            sendRequest(bulkRequest);
         }
         IOUtils.closeQuietly(client);
         super.teardownTest(context);
+    }
+    
+    private void sendRequest(BulkRequest bulkRequest) throws IOException {
+        BulkResponse bulkResponse = this.client.bulk(bulkRequest);
+        if (bulkResponse.hasFailures()) {
+            if(logger.isErrorEnabled()) {
+                logger.error("Failed to write a result on {}: {}",
+                        index, bulkResponse.buildFailureMessage());
+            }
+        } else {
+            logger.debug("Wrote {} results in {}.",
+                    index);
+        }
     }
 
     public Map<String, Object> getElasticData(SampleResult sr, BackendListenerContext context) {
@@ -172,7 +183,7 @@ public class ElasticsearchBackend extends AbstractBackendListenerClient {
         //all assertions
         AssertionResult[] assertionResults = sr.getAssertionResults();
         if(assertionResults != null) {
-            HashMap<String, Object> [] assertionArray = new HashMap[assertionResults.length];
+            Map<String, Object>[] assertionArray = new HashMap[assertionResults.length];
             Integer i = 0;
             for(AssertionResult assertionResult : assertionResults) {
                 HashMap<String, Object> assertionMap = new HashMap<>();


### PR DESCRIPTION
This comments #12

Note that:
- I have not tested it yet. I am PR so that you can continue work as I
won't have time this upcoming week
- It seems I hit a bug in maven shade if I try to minimize or relocate,
built fails with IllegalArgumentException

Also note the following changes which should be documented in release
notes:
- No more cluster parameter configuration
- Port has changed from 9300 (Transport API Port) to 9200 (Rest ApI
port)
- New scheme parameter
- We should add connect/read and bulk timeouts (we only have 1 timeout)
- I didn't use Async API as I don't think there is benefit here, but you
may want to try it
- I upgraded dependency to ES 6.0.0