### PR TITLE
Fixed issue with sending JMeter vars via X-es-backend header prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: java
 jdk:
-- oraclejdk9
+  - openjdk10
+
+sudo: true
+cache:
+  directories:
+    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration> 
+					<source>8</source> 
+				</configuration> 
 				<version>2.9.1</version>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.8</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
@@ -206,28 +206,35 @@ public class ElasticSearchMetric {
      */
     private void parseHeadersAsJsonProps(boolean allReqHeaders, boolean allResHeaders) {
         LinkedList<String[]> headersArrayList = new LinkedList<String[]>();
+		
+		if (allReqHeaders) {
+			headersArrayList.add(this.sampleResult.getRequestHeaders().split("\n"));
+		}
 
-        if (allReqHeaders) {
-            headersArrayList.add(this.sampleResult.getRequestHeaders().split("\n"));
-        }
-
-        if (allResHeaders) {
-            headersArrayList.add(this.sampleResult.getResponseHeaders().split("\n"));
-        }
+		if (allResHeaders) {
+			headersArrayList.add(this.sampleResult.getResponseHeaders().split("\n"));
+		}
+		
+		if (!allReqHeaders && !allResHeaders) {
+			headersArrayList.add(this.sampleResult.getRequestHeaders().split("\n"));
+			headersArrayList.add(this.sampleResult.getResponseHeaders().split("\n"));
+		}
 
         for(String[] lines : headersArrayList) {
             for(int i=0; i < lines.length; i++) {
                 String[] header = lines[i].split(":",2);
 
-                // if not all req headers and header contains special X-tag
-                if (header.length > 1) {
-                    if (!this.allReqHeaders && header[0].startsWith("X-es-backend")) {
-                        this.json.put(header[0].replaceAll("es-", "").trim(), header[1].trim());
-                    } else {
-                        this.json.put(header[0].replaceAll("es-", "").trim(), header[1].trim());
-                    }
-                }
-            }
+                // if not all res/req headers and header contains special X-tag
+                if (!allReqHeaders && !allResHeaders && header.length > 1) {
+                    if (header[0].startsWith("X-es-backend")) {
+                        this.json.put(header[0].replaceAll("X-es-backend-", "").trim(), header[1].trim());
+					}
+				}
+						
+                if ((allReqHeaders || allResHeaders) && header.length > 1) {
+					this.json.put(header[0].trim(), header[1].trim());
+				}
+			}
         }
     }
 


### PR DESCRIPTION
Attempt to address issues with https://github.com/delirius325/jmeter-elasticsearch-backend-listener/issues/31

1. Will add JMeter variable to sampler data even if es.parse.all.req.headers or es.parse.all.res.headers are set to false.
2. Made small change to replaceAll in header key to be 'X-es-backend-' rather than 'es-'
3. Small config change to pom.xml to allow successful building in Java 11

Tested successfully in JMeter 5.1.1 r1855137.  ElasticSearch v5.6.9
Tested four scenarios under light load.
1. Set X-es-backend- header key/value.  es.parse.all.req.headers=false.  es.parse.all.res.headers=false. 
2. Set X-es-backend- header key/value.  es.parse.all.req.headers=true.  es.parse.all.res.headers=false. 
3. Set X-es-backend- header key/value.  es.parse.all.req.headers=false.  es.parse.all.res.headers=true. 
4. Set X-es-backend- header key/value.  es.parse.all.req.headers=true.  es.parse.all.res.headers=true.  
In all cases the X-es-backend- key/value appeared as expected.