### PR TITLE
I have implemented SampleLabel parsing, which can be used to send custom fields to ElasticSearch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.delirius325</groupId>
 	<artifactId>jmeter.backendlistener.elasticsearch</artifactId>
-	<version>2.7.0</version>
+	<version>2.8.0</version>
 	<packaging>jar</packaging>
 
 	<name>jmeter.backendlistener.elasticsearch</name>

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
@@ -293,9 +293,11 @@ public class ElasticSearchMetric {
     }
 
     /**
-     * Adds key-value pairs splitted from SampleLabel by delimiters
-     * Eg. SampleLabel "Id:01_Transaction:Login" is parsed as field name
-     * "Id" with value "01" and field name "Transaction" with value "Login" (if delimiters are _ and :)
+     * Adds key-value pairs which are split from SampleLabel by delimiters
+     * Eg. SampleLabel "Id:01_Transaction:Login" is parsed as:
+     *  field name "Id" with value "01"
+     *  field name "Transaction" with value "Login"
+     *  (if default delimiters are used)
      */
     private void addSplittedSampleLabel() {
         if (this.sampleResult.getSampleLabel().contains(this.sampleLabelDelimiter)
@@ -303,8 +305,8 @@ public class ElasticSearchMetric {
             String[] sampleLabelParams = this.sampleResult.getSampleLabel().split(this.sampleLabelDelimiter);
             for (String param : sampleLabelParams) {
                 if (param.contains(this.parseSampleLabelKeyValueDelimiter)) {
-                    String[] splittedParams = param.split(this.parseSampleLabelKeyValueDelimiter);
-                    addFilteredJSON(splittedParams[0], splittedParams[1]);
+                    String[] splitParams = param.split(this.parseSampleLabelKeyValueDelimiter);
+                    addFilteredJSON(splitParams[0], splitParams[1]);
                 }
             }
         }

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetric.java
@@ -32,10 +32,14 @@ public class ElasticSearchMetric {
     private Set<String> fields;
     private boolean allReqHeaders;
     private boolean allResHeaders;
+    private boolean parseSampleLabel;
+    private String sampleLabelDelimiter;
+    private String parseSampleLabelKeyValueDelimiter;
 
     public ElasticSearchMetric(
             SampleResult sr, String testMode, String timeStamp, int buildNumber,
-            boolean parseReqHeaders, boolean parseResHeaders, Set<String> fields) {
+            boolean parseReqHeaders, boolean parseResHeaders, Set<String> fields, boolean parseSampleLabel,
+            String parseSampleLabelDelimiter, String parseSampleLabelKeyValueDelimiter) {
         this.sampleResult = sr;
         this.esTestMode = testMode.trim();
         this.esTimestamp = timeStamp.trim();
@@ -44,6 +48,9 @@ public class ElasticSearchMetric {
         this.allReqHeaders = parseReqHeaders;
         this.allResHeaders = parseResHeaders;
         this.fields = fields;
+        this.parseSampleLabel = parseSampleLabel;
+        this.sampleLabelDelimiter = parseSampleLabelDelimiter;
+        this.parseSampleLabelKeyValueDelimiter = parseSampleLabelKeyValueDelimiter;
     }
 
     /**
@@ -98,6 +105,9 @@ public class ElasticSearchMetric {
         addAssertions();
         addElapsedTime();
         addCustomFields(context);
+        if (parseSampleLabel) {
+            addSplittedSampleLabel();
+        }
         parseHeadersAsJsonProps(this.allReqHeaders, this.allResHeaders);
 
         return this.json;
@@ -279,6 +289,24 @@ public class ElasticSearchMetric {
         } catch (ParseException e) {
             logger.error("Unexpected error occured computing elapsed date", e);
             return null;
+        }
+    }
+
+    /**
+     * Adds key-value pairs splitted from SampleLabel by delimiters
+     * Eg. SampleLabel "Id:01_Transaction:Login" is parsed as field name
+     * "Id" with value "01" and field name "Transaction" with value "Login" (if delimiters are _ and :)
+     */
+    private void addSplittedSampleLabel() {
+        if (this.sampleResult.getSampleLabel().contains(this.sampleLabelDelimiter)
+                || this.sampleResult.getSampleLabel().contains(this.parseSampleLabelKeyValueDelimiter) ) {
+            String[] sampleLabelParams = this.sampleResult.getSampleLabel().split(this.sampleLabelDelimiter);
+            for (String param : sampleLabelParams) {
+                if (param.contains(this.parseSampleLabelKeyValueDelimiter)) {
+                    String[] splittedParams = param.split(this.parseSampleLabelKeyValueDelimiter);
+                    addFilteredJSON(splittedParams[0], splittedParams[1]);
+                }
+            }
         }
     }
 

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetricSender.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetricSender.java
@@ -39,7 +39,7 @@ public class ElasticSearchMetricSender {
 
     /**
      * This method returns the current size of the ElasticSearch documents list
-     * 
+     *
      * @return integer representing the size of the ElasticSearch documents list
      */
     public int getListSize() {
@@ -62,7 +62,7 @@ public class ElasticSearchMetricSender {
 
     /**
      * This method adds a metric to the list (metricList).
-     * 
+     *
      * @param metric
      *            String parameter representing a JSON document for ElasticSearch
      */
@@ -95,50 +95,50 @@ public class ElasticSearchMetricSender {
             logger.info("Index already exists!");
         }
     }
-    
+
     public int getElasticSearchVersion() {
-    	Request request = new Request("GET", "/" );
-    	int elasticSearchVersion = -1;
-    	 try {
-             Response response = this.client.performRequest(setAuthorizationHeader(request));
-             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK && logger.isErrorEnabled()) {
-                 logger.error("Unable to perform request to ElasticSearch engine for index {}. Response status: {}",
-                              this.esIndex, response.getStatusLine().toString());
-             }else {
-            	 String responseBody = EntityUtils.toString(response.getEntity());
-     			 JSONObject elasticSearchConfig = new JSONObject(responseBody);
-     			 JSONObject version  = (JSONObject) elasticSearchConfig.get("version");
-     			 String elasticVersion =  version.get("number").toString();
-     			 elasticSearchVersion = Integer.parseInt(elasticVersion.split("\\.")[0]);
-                 logger.info("ElasticSearch Version : "  + Integer.toString(elasticSearchVersion));
-             }
-         } catch (Exception e) {
-             if (logger.isErrorEnabled()) {
-                 logger.error("Exception" + e);
-                 logger.error("ElasticSearch Backend Listener was unable to perform request to the ElasticSearch engine. Check your JMeter console for more info.");
-             }
-         }
-    	 return elasticSearchVersion;
+        Request request = new Request("GET", "/" );
+        int elasticSearchVersion = -1;
+        try {
+            Response response = this.client.performRequest(setAuthorizationHeader(request));
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK && logger.isErrorEnabled()) {
+                logger.error("Unable to perform request to ElasticSearch engine for index {}. Response status: {}",
+                        this.esIndex, response.getStatusLine().toString());
+            }else {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                JSONObject elasticSearchConfig = new JSONObject(responseBody);
+                JSONObject version  = (JSONObject) elasticSearchConfig.get("version");
+                String elasticVersion =  version.get("number").toString();
+                elasticSearchVersion = Integer.parseInt(elasticVersion.split("\\.")[0]);
+                logger.info("ElasticSearch Version : "  + Integer.toString(elasticSearchVersion));
+            }
+        } catch (Exception e) {
+            if (logger.isErrorEnabled()) {
+                logger.error("Exception" + e);
+                logger.error("ElasticSearch Backend Listener was unable to perform request to the ElasticSearch engine. Check your JMeter console for more info.");
+            }
+        }
+        return elasticSearchVersion;
     }
-    
+
 
     /**
      * This method sends the ElasticSearch documents for each document present in the list (metricList). All is being
      * sent through the low-level ElasticSearch REST Client.
      */
     public void sendRequest(int elasticSearchVersionPrefix) {
-    	Request request;
-    	StringBuilder bulkRequestBody = new StringBuilder();
-    	String actionMetaData;
-    	if(elasticSearchVersionPrefix < 7) {
-    		 request = new Request("POST", "/" + this.esIndex + "/SampleResult/_bulk");
- 			 actionMetaData = String.format(SEND_BULK_REQUEST, this.esIndex, "SampleResult");
-    	}
-    	else {
-    		 request = new Request("POST", "/" + this.esIndex + "/_bulk");
-    		 actionMetaData = String.format(SEND_BULK_REQUEST, this.esIndex);
-    	}
-    		
+        Request request;
+        StringBuilder bulkRequestBody = new StringBuilder();
+        String actionMetaData;
+        if(elasticSearchVersionPrefix < 7) {
+            request = new Request("POST", "/" + this.esIndex + "/SampleResult/_bulk");
+            actionMetaData = String.format(SEND_BULK_REQUEST, this.esIndex, "SampleResult");
+        }
+        else {
+            request = new Request("POST", "/" + this.esIndex + "/_bulk");
+            actionMetaData = String.format(SEND_BULK_REQUEST, this.esIndex);
+        }
+
         for (String metric : this.metricList) {
             bulkRequestBody.append(actionMetaData);
             bulkRequestBody.append(metric);
@@ -154,10 +154,10 @@ public class ElasticSearchMetricSender {
             if (logger.isErrorEnabled()) {
                 if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                     logger.error("ElasticSearch Backend Listener failed to write results for index {}. Response status: {}",
-                                 this.esIndex, response.getStatusLine().toString());
+                            this.esIndex, response.getStatusLine().toString());
                 } else {
                     logger.debug("ElasticSearch Backend Listener has successfully written to ES instance [{}] _bulk request {}",
-                                 client.getNodes().iterator().next().getHost().toHostString(), request.toString());
+                            client.getNodes().iterator().next().getHost().toHostString(), request.toString());
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/TestElasticSearchBackend.java
+++ b/src/test/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/TestElasticSearchBackend.java
@@ -18,9 +18,9 @@ public class TestElasticSearchBackend {
     @Before
     public void setUp() throws Exception {
         metricCI = new ElasticSearchMetric(new SampleResult(), "info", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ", 1, false, false,
-                new HashSet<String>());
+                new HashSet<String>(), false, "_", ":");
         metricNoCI = new ElasticSearchMetric(new SampleResult(), "info", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ", 0, false,
-                false, new HashSet<String>());
+                false, new HashSet<String>(), false, "_", ":");
     }
 
     @Test


### PR DESCRIPTION
It uses SampleLabel which is split by delimiter (default is “\_”) and then for each split value it adds key-value pairs based on second delimiter (default is “:”). 
 Example: 
 ![JMeter_SampleLabel](https://user-images.githubusercontent.com/58358727/91728637-a8a7fe80-eba3-11ea-8880-64a4871c493a.png)
SampleLabel "Id:01_Transaction:Login" is split by delimiter “_” as
1.	Id:01
2.	Transaction:Login

which is then split as key-value pairs by delimiter “:”
1.	key = Id, value = 01
2.	key = Transaction, value = Login

and sent to ElasticSearch.

There are 3 new settings for the plugin:
 ![JMeter_SampleLabel_plugin_additions](https://user-images.githubusercontent.com/58358727/91728656-af367600-eba3-11ea-8ceb-771c15e6ff9c.png)

1. _es.parse.samplelabel_ – turn on and off SampleLabel parsing (default is off)

2. _es.parse.samplelabel.delimiter_ – delimiter for splitting each parameter
3. _es.parse.samplelabel.keyvalue.delimiter_ – delimiter for splitting key-value pairs from parameter
