### PR TITLE
Added ability to handle sub-results after handling a sample

### DIFF
--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticsearchBackendClient.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticsearchBackendClient.java
@@ -43,6 +43,7 @@ public class ElasticsearchBackendClient extends AbstractBackendListenerClient {
     private static final String ES_AUTH_PWD = "es.xpack.password";
     private static final String ES_PARSE_REQ_HEADERS = "es.parse.all.req.headers";
     private static final String ES_PARSE_RES_HEADERS = "es.parse.all.res.headers";
+    private static final String ES_HANDLE_SUB_RESULTS = "es.handle.sub.results";
     private static final String ES_AWS_ENDPOINT = "es.aws.endpoint";
     private static final String ES_AWS_REGION = "es.aws.region";
     private static final String ES_SSL_TRUSTSTORE_PATH = "es.ssl.truststore.path";
@@ -71,6 +72,7 @@ public class ElasticsearchBackendClient extends AbstractBackendListenerClient {
         DEFAULT_ARGS.put(ES_AUTH_PWD, "");
         DEFAULT_ARGS.put(ES_PARSE_REQ_HEADERS, "false");
         DEFAULT_ARGS.put(ES_PARSE_RES_HEADERS, "false");
+        DEFAULT_ARGS.put(ES_HANDLE_SUB_RESULTS, "false");
         DEFAULT_ARGS.put(ES_AWS_ENDPOINT,  "");
         DEFAULT_ARGS.put(ES_AWS_REGION, "");
         DEFAULT_ARGS.put(ES_SSL_TRUSTSTORE_PATH, "");
@@ -241,6 +243,15 @@ public class ElasticsearchBackendClient extends AbstractBackendListenerClient {
                     logger.error(
                             "The ElasticSearch Backend Listener was unable to add sampler to the list of samplers to send... More info in JMeter's console.");
                     e.printStackTrace();
+                }
+            }
+
+            // Iterate through sub-results, if desired - this allows use of 'generate parent sample' in transaction controllers whilst still handling all samples
+            if (context.getBooleanParameter(ES_HANDLE_SUB_RESULTS, false)) {
+                try {
+                    handleSampleResults(Arrays.asList(sr.getSubResults()), context);
+                } catch (Exception e) {
+                    logger.error("The ElasticSearch Backend Listener failed to handle sampler sub-results.", e);
                 }
             }
         }


### PR DESCRIPTION
I did see that there was another PR open from another user to accomplish the same goal, however the other PR would only enable two levels of sub-results.  It was not truly recursive, it just tried immediate children, and then one more time.  It also used a lot of code to accomplish that.  I think the desired effect can be achieved pretty elegantly by recursively calling `handleSampleResults()` with the sub-results while processing each sample.

As was the case with the other PR, I agree that enabling this feature with a flag, defaulting to false, makes sense.  In doing so, the default behaviour does not change for existing users, but it becomes available for those who need it.

Thanks!  Great plugin, but this change would really help us structure our test plans more elegantly.