### PR TITLE
Use index operation instead of create

### DIFF
--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetricSender.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchMetricSender.java
@@ -110,7 +110,7 @@ public class ElasticSearchMetricSender {
      			 JSONObject elasticSearchConfig = new JSONObject(responseBody);
      			 JSONObject version  = (JSONObject) elasticSearchConfig.get("version");
      			 String elasticVersion =  version.get("number").toString();
-                 if (Objects.equals(version.get("distribution").toString(), "opensearch")) {
+                 if (Objects.equals(JsonUtils.getValueOrNull(version, "distribution"), "opensearch")) {
                     elasticSearchVersion = 7;
                  }else{
                     elasticSearchVersion = Integer.parseInt(elasticVersion.split("\\.")[0]);

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchRequests.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/ElasticSearchRequests.java
@@ -4,5 +4,5 @@ public class ElasticSearchRequests {
     /**
      * Request to send metrics (JMeter/Percentiles) as ElasticSearch documents
      */
-    public static String SEND_BULK_REQUEST = "{ \"create\" : { \"_index\" : \"%s\" } }%n";
+    public static String SEND_BULK_REQUEST = "{ \"index\" : { \"_index\" : \"%s\" } }%n";
 }

--- a/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/JsonUtils.java
+++ b/src/main/java/io/github/delirius325/jmeter/backendlistener/elasticsearch/JsonUtils.java
@@ -1,0 +1,15 @@
+package io.github.delirius325.jmeter.backendlistener.elasticsearch;
+
+import org.json.JSONObject;
+
+import java.net.HttpRetryException;
+
+public class JsonUtils {
+    public static <T> T getValueOrNull(JSONObject object, String key) {
+        try {
+            return (T) object.get(key);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Using the index operation instead of create allows the omission of the ID field.

This makes the listener work with ES > 5.0